### PR TITLE
Fix broken pickup location retrieval

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
@@ -377,7 +377,7 @@ sub pickup_locations {
         my $limit_type = C4::Context->preference('BranchTransferLimitsType');
         my $limits = Koha::Item::Transfer::Limits->search({
             fromBranch  => $self->item->holdingbranch,
-            $limit_type => $self->item->branch_transfer_limit_code,
+            $limit_type => $limit_type eq 'itemtype' ? $self->item->effective_itemtype : $self->item->ccode
         })->unblessed;
 
         foreach my $library (@$pickup_libraries) {


### PR DESCRIPTION
The method branch_transfer_limit_code is only available in Koha-Suomi
Koha version and the call fails because of that. This reimplements
that functionality.