### PR TITLE
Fix hold availability calculation with newer Koha versions

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/LibraryItemRule.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/LibraryItemRule.pm
@@ -86,7 +86,7 @@ sub hold_not_allowed_by_library {
 
     return unless my $rule = $self->branchitemrule;
 
-    if (!$rule->{holdallowed}) {
+    if ($rule->{holdallowed} =~ m/^(0|not_allowed)$/) { # 0 means not_allowed in older Koha versions
         return Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Hold::NotAllowedByLibrary->new
     }
     return;
@@ -109,7 +109,7 @@ sub hold_not_allowed_by_other_library {
     my $independentBranch = C4::Context->preference('IndependentBranches');
 
     my $patron = $self->patron;
-    if ($rule->{holdallowed} == 1) {
+    if ($rule->{holdallowed} =~ m/^(1|from_home_library)$/) { # 1 means from_home_library in older Koha versions
         if (!$patron) {
             # Since we don't know who is asking for item and from which
             # library, return NotAllowedFromOtherLibraries, but it should


### PR DESCRIPTION
The holds availability calculation stopped working after the commit
"Bug 27069: Adapt uses of holdallowed" (1d9d05613b9) was introduced in
Koha. The return value of GetBranchItemRule() is now a string in newer
Koha versions. To keep the plugin working with older Koha versions we
keep the checks for integer return values as well.