### PR TITLE
Fix patrons endpoint with newest Koha version

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
@@ -83,7 +83,9 @@ sub get {
                 $api_record->{firstname} = $guarantor_record->firstname;
                 push @guarantors, $api_record;
             }
-            my $relationship = $patron->relationship;
+
+            # We need to check if relationship column exists, it was dropped in bug 26995
+            my $relationship = exists $ret->{'relationship_type'} ? $patron->relationship : undef;
             if ($relationship && $patron->contactname) {
                 my $api_record;
                 $api_record->{'relationship'} = $relationship;


### PR DESCRIPTION
The current Koha master version doesn't contain anymore the
borrowers.relationship column (Bug 26995). This checks (hackily) via
relationship_type hash key whether the column still exists or not and
only calls $patron->relationship if it exists. Without this check we
get the following error:

The method Koha::Patron->relationship is not covered by tests!