### PR TITLE
After Koha v21.06.00.031 dt_from_string needs to be loaded explicitly…

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability.pm
@@ -20,7 +20,7 @@ package Koha::Plugin::Fi::KohaSuomi::DI::Koha::Availability;
 
 use Modern::Perl;
 
-use Koha::DateUtils;
+use Koha::DateUtils qw( dt_from_string );
 
 use Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions;
 

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Checkout.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Checkout.pm
@@ -25,7 +25,7 @@ use base qw(Koha::Plugin::Fi::KohaSuomi::DI::Koha::Availability::Checks);
 use C4::Circulation;
 use C4::Context;
 
-use Koha::DateUtils;
+use Koha::DateUtils qw( dt_from_string );
 use Koha::Items;
 
 use Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Biblio;

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
@@ -28,7 +28,7 @@ use C4::Reserves;
 
 use Koha::AuthorisedValues;
 use Koha::Database;
-use Koha::DateUtils;
+use Koha::DateUtils qw( dt_from_string );
 use Koha::Holds;
 use Koha::ItemTypes;
 use Koha::Items;


### PR DESCRIPTION
… from Koha::DateUtils

Caused error:
```
Use of inherited AUTOLOAD for non-method
Koha::Plugin::Fi::KohaSuomi::DI::Koha::Availability::Checks::Item::dt_from_string()
is no longer allowed at .../Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm line 73.
```