### PR TITLE
Fix compatibility with Koha 22.05.  (#12)

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/CirculationRule.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/CirculationRule.pm
@@ -234,11 +234,11 @@ sub on_shelf_holds_forbidden {
     } elsif ($on_shelf_holds == 1) {
         return;
     } elsif ($on_shelf_holds == 2) {
-        my @items = Koha::Items->search({ biblionumber => $item->biblionumber });
+        my $items = Koha::Items->search({ biblionumber => $item->biblionumber });
 
         my $any_available = 0;
 
-        foreach my $i (@items) {
+        while ( my $i = $items->next ) {
             unless ($i->itemlost
               || $i->notforloan > 0
               || $i->withdrawn

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/ArticleRequest.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/ArticleRequest.pm
@@ -133,7 +133,7 @@ sub _item_looper {
     if (@hostitemnumbers) {
         my @hostitems = Koha::Items->search({
             itemnumber => { 'in' => @hostitemnumbers }
-        });
+        })->as_list;
         push @items, @hostitems;
     }
 

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/Hold.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/Hold.pm
@@ -122,7 +122,7 @@ sub _item_looper {
     if (@hostitemnumbers) {
         my @hostitems = Koha::Items->search({
             itemnumber => { 'in' => @hostitemnumbers }
-        });
+        })->as_list;
         push @items, @hostitems;
     }
 

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/Search.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/Search.pm
@@ -89,7 +89,7 @@ sub _item_looper {
     if (@hostitemnumbers) {
         my @hostitems = Koha::Items->search({
             itemnumber => { 'in' => @hostitemnumbers }
-        });
+        })->as_list;
         push @items, @hostitems;
     }
 


### PR DESCRIPTION
Koha::Objects not anymore uses "wantarray" detection in ->search(, so
it never returns list so ->as_list should be added, or iterator should
($items->next) be used.

Note: only Koha::Plugin::Fi::KohaSuomi::DI::Koha::Availability::Checks::CirculationRule directly tested :)