### PR TITLE
Fix paginator header warning

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
@@ -442,12 +442,14 @@ sub list_checkouts {
         $filtered_params->{borrowernumber} = $patron->borrowernumber;
 
         # Perform search
+        my $checkouts_base_total = $checkouts_set->count();
         my $checkouts = $checkouts_set->search( $filtered_params, $attributes );
 
         if ($checkouts->is_paged) {
             $c->add_pagination_headers({
                 total => $checkouts->pager->total_entries,
                 params => $args,
+                base_total => $checkouts_base_total,
             });
         }
 


### PR DESCRIPTION
[WARN] Use of uninitialized value $_ in transliteration (tr///) at /usr/local/share/perl/5.30.0/Mojo/Headers.pm line 38.

In add_pagination_headers value of base_total is required one.