### PR TITLE
Limit permissions on patron validation endpoint

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/openapi.yaml
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/openapi.yaml
@@ -56,7 +56,7 @@ paths:
         - patrons
       x-koha-authorization:
         permissions:
-          borrowers: "1"
+          borrowers: "view_borrower_infos_from_any_libraries"
       x-mojo-to: Fi::KohaSuomi::DI::PatronController#validate_credentials
   "/availability/biblios/{biblio_id}/articlerequest":
     get:
@@ -654,7 +654,7 @@ paths:
         - patrons
       x-koha-authorization:
         permissions:
-          borrowers: "1"
+          borrowers: "view_borrower_infos_from_any_libraries"
       x-mojo-to: Fi::KohaSuomi::DI::PatronController#validate_credentials
   "/patrons/{patron_id}":
     get:


### PR DESCRIPTION
Patron's validation endpoint needs all patron permissons. This update narrows it down to only use view_borrower_infos_from_any_libraries permission.