### PR TITLE
Since 22.11 call params to checkpw_internal differs

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
@@ -556,7 +556,10 @@ sub validate_credentials {
     }
 
     my $dbh = C4::Context->dbh;
-    unless (C4::Auth::checkpw_internal($dbh, $userid, $password)) {
+    unless (C4::Context->preference('Version') ge '22.110000'
+                ? C4::Auth::checkpw_internal($userid, $password)
+                : C4::Auth::checkpw_internal($dbh, $userid, $password)
+        ) {
         return $c->render(
             status => 401, 
             openapi => { error => "Login failed." }


### PR DESCRIPTION
(reference: Bug 27342: Remove dbh from C4::Auth)