### PR TITLE
Fix compatibility with Koha 22.12

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Checkout.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Checkout.pm
@@ -96,8 +96,15 @@ sub no_more_renewals {
     my ($self, $issue) = @_;
 
     return unless $issue;
-    my ($status) = C4::Circulation::CanBookBeRenewed($issue->borrowernumber,
+    my $status;
+    if (C4::Context->preference('Version') ge '22.120000') {
+
+        ($status) = C4::Circulation::CanBookBeRenewed($issue->patron,
+             $issue);
+    } else {
+        ($status) = C4::Circulation::CanBookBeRenewed($issue->borrowernumber,
              $issue->itemnumber);
+    }
     if ($status == 0) {
         return Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Checkout::NoMoreRenewals->new;
     }

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
@@ -176,7 +176,9 @@ sub held {
     my ($self) = @_;
 
     my $item = $self->item;
-    if (my ($s, $reserve) = C4::Reserves::CheckReserves($item->itemnumber)) {
+    if (my ($s, $reserve) = C4::Reserves::CheckReserves(C4::Context->preference('Version') ge '22.120000'
+                ? $item
+                : $item->itemnumber)) {
         if (!$reserve) {
             return;
         }

--- a/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
@@ -512,9 +512,15 @@ sub list_checkouts {
 
             $result->{'max_renewals'} = $max_renewals;
             if (!$blocks) {
-                ($can_renew, $blocks) = C4::Circulation::CanBookBeRenewed(
-                    $patron->borrowernumber, $checkout->itemnumber
-                );
+                if (C4::Context->preference('Version') ge '22.120000') {
+                    ($can_renew, $blocks) = C4::Circulation::CanBookBeRenewed(
+                        $patron, $checkout
+                    );
+                } else {
+                    ($can_renew, $blocks) = C4::Circulation::CanBookBeRenewed(
+                        $patron->borrowernumber, $checkout->itemnumber
+                    );
+                }
             }
 
             $result->{'renewable'} = $can_renew ? Mojo::JSON->true : Mojo::JSON->false;


### PR DESCRIPTION
Modified function calls to handle different Koha versions:
- 'C4::Circulation::CanBookBeRenewed' in Checkout.pm and PatronController.pm
- 'C4::Reserves::CheckReserves' in Item.pm