### PR TITLE
Fix compatibility with Koha 23.05 (22.12)

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Checkout.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Checkout.pm
@@ -96,8 +96,7 @@ sub no_more_renewals {
     my ($self, $issue) = @_;
 
     return unless $issue;
-    my ($status) = C4::Circulation::CanBookBeRenewed($issue->borrowernumber,
-             $issue->itemnumber);
+    my ($status) = C4::Circulation::CanBookBeRenewed($issue->patron, $issue);
     if ($status == 0) {
         return Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Checkout::NoMoreRenewals->new;
     }

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
@@ -176,7 +176,7 @@ sub held {
     my ($self) = @_;
 
     my $item = $self->item;
-    if (my ($s, $reserve) = C4::Reserves::CheckReserves($item->itemnumber)) {
+    if (my ($s, $reserve) = C4::Reserves::CheckReserves($item)) {
         if (!$reserve) {
             return;
         }

--- a/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
@@ -554,10 +554,7 @@ sub validate_credentials {
     }
 
     my $dbh = C4::Context->dbh;
-    unless (C4::Context->preference('Version') ge '22.110000'
-                ? C4::Auth::checkpw_internal($userid, $password)
-                : C4::Auth::checkpw_internal($dbh, $userid, $password)
-        ) {
+    unless (C4::Auth::checkpw_internal($userid, $password)) {
         return $c->render(
             status => 401, 
             openapi => { error => "Login failed." }

--- a/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/PatronController.pm
@@ -512,9 +512,7 @@ sub list_checkouts {
 
             $result->{'max_renewals'} = $max_renewals;
             if (!$blocks) {
-                ($can_renew, $blocks) = C4::Circulation::CanBookBeRenewed(
-                    $patron->borrowernumber, $checkout->itemnumber
-                );
+                ($can_renew, $blocks) = C4::Circulation::CanBookBeRenewed($patron, $checkout);
             }
 
             $result->{'renewable'} = $can_renew ? Mojo::JSON->true : Mojo::JSON->false;


### PR DESCRIPTION
Modified function calls to handle different Koha versions:
- 'C4::Circulation::CanBookBeRenewed' in Checkout.pm and PatronController.pm
- 'C4::Reserves::CheckReserves' in Item.pm