### PR TITLE
Add a check for a recall to determine if item is available

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
@@ -567,5 +567,18 @@ sub _pickup_location_allowed {
     return $context_cache->{items_available_by_location}->{$location} ? 0 : 1;
 }
 
+=head3 recalled
+
+Returns Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Item::Recalled if item has been recalled.
+
+=cut
+
+sub recalled {
+    my ($self) = @_;
+
+    if ($self->item->recall) {
+        return Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Item::Recalled->new;
+    }
+}
 
 1;

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Exceptions/Item.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Exceptions/Item.pm
@@ -87,6 +87,10 @@ use Exception::Class (
      'Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Item::Withdrawn' => {
         isa =>  'Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Item',
         description => "Item is marked as withdrawn.",
+    },
+    'Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Item::Recalled' => {
+        isa =>  'Koha::Plugin::Fi::KohaSuomi::DI::Koha::Exceptions::Item',
+        description => "Item has been recalled.",
     }
 
 );

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Item/Availability/Search.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Item/Availability/Search.pm
@@ -19,6 +19,7 @@ package Koha::Plugin::Fi::KohaSuomi::DI::Koha::Item::Availability::Search;
 # along with Koha; if not, see <http://www.gnu.org/licenses>.
 
 use Modern::Perl;
+use C4::Context;
 
 use base qw(Koha::Plugin::Fi::KohaSuomi::DI::Koha::Item::Availability);
 
@@ -57,6 +58,9 @@ sub in_opac {
     }
     if (!$params->{'ignore_transfer'}) {
         $self->unavailable($reason) if $reason = $itemcalc->transfer;
+    }
+    if (C4::Context->preference('UseRecalls')) {
+        $self->unavailable($reason) if $reason = $itemcalc->recalled;
     }
 
     return $self;

--- a/Koha/Plugin/Fi/KohaSuomi/DI/openapi/definitions/availability/reason.yaml
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/openapi/definitions/availability/reason.yaml
@@ -281,6 +281,10 @@ properties:
           - integer
           - "null"
     type: object
+  Item::Recalled:
+    description: Item has been recalled.
+    properties: {}
+    type: object
   Patron::AgeRestricted:
     description: An age restriction applies for this patron.
     properties:


### PR DESCRIPTION
We want search results to show that a recall has been requested of an item and it is unavailable to be circulated.