### PR TITLE
Check if a pickup location is blocked by a patron category library limitations

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
@@ -543,7 +543,7 @@ sub _pickup_location_allowed {
     if ( !defined $context_cache->{patron_category_library_limitation}->{$location} ) {
         my $category = Koha::Patron::Categories->find($patron->categorycode);
         if ( $category->library_limits ) {
-            if ( grep /$location/, $category->library_limits->get_column('branchcode') ) {
+            if ( grep /^$location\z/, $category->library_limits->get_column('branchcode') ) {
                 return $context_cache->{patron_category_library_limitation}->{$location} = 1;
             } else {
                 return $context_cache->{patron_category_library_limitation}->{$location} = 0;

--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Availability/Checks/Item.pm
@@ -538,6 +538,19 @@ Checks if pickup location is allowed. $context_cache is a hash ref used to store
 sub _pickup_location_allowed {
     my ($self, $location, $patron, $context_cache) = @_;
 
+    # Skip pickup locations if those branches are not allowed in the patron
+    # category library limitations
+    if ( !defined $context_cache->{patron_category_library_limitation}->{$location} ) {
+        my $category = Koha::Patron::Categories->find($patron->categorycode);
+        if ( $category->library_limits ) {
+            if ( grep /$location/, $category->library_limits->get_column('branchcode') ) {
+                return $context_cache->{patron_category_library_limitation}->{$location} = 1;
+            } else {
+                return $context_cache->{patron_category_library_limitation}->{$location} = 0;
+            }
+        }
+    }
+
     if (!defined $context_cache->{can_place_hold_if_available_at_pickup}) {
         my $can_place = C4::Context->preference('OPACHoldsIfAvailableAtPickup');
         unless ($can_place || !$patron) {


### PR DESCRIPTION
Some libraries do not want specific branches to ever be available to certain patron categories. 

In Koha it is possible to 'hide' patron categories from particular library branches. The inverse is also possible - hide specific branches, as pickup locations, for a patron category using library limitations.

Sponsored-by: Auckland University of Technology, New Zealand