### PR TITLE
Fix void sort.

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/Search.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/Search.pm
@@ -106,8 +106,8 @@ sub _item_looper {
     }
 
     # Sort items for paging
-    sort { $a->itemnumber <=> $b->itemnumber } @items;
- 
+    @items = sort { $a->itemnumber <=> $b->itemnumber } @items;
+
     my $opachiddenitems_rules = C4::Context->yaml_preference('OpacHiddenItems');
 
     my $avoid_queries_after = $params->{'MaxSearchResultsItemsPerRecordStatusCheck'}


### PR DESCRIPTION
From logs:

[WARN] Useless use of sort in void context at /var/lib/koha/hamk/plugins/Koha/Plugin/Fi/KohaSuomi/DI/Koha/Biblio/Availability/Search.pm line 109.