### PR TITLE
Add default format for Article request if nothing provided by API request to prevent exceptions

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/DI/ArticleRequestController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/DI/ArticleRequestController.pm
@@ -126,6 +126,12 @@ sub add {
     my $pages      = $body->{pages};
     my $chapters   = $body->{chapters};
 
+    # We set default values for format if it does not come from API request,
+    # otherwise Koha almost silently dies with Koha::Exceptions::ArticleRequest::WrongFormat
+    # (for a moment of a patch formats was SCAN|PHOTOCOPY, check the pref value below)
+    my $formats = C4::Context->multivalue_preference('ArticleRequestsSupportedFormats');
+    my $format  = $body->{format} // $formats->[0];
+
     my $patron = Koha::Patrons->find($patron_id);
 
     unless ($patron) {
@@ -172,6 +178,7 @@ sub add {
             pages          => $pages,
             chapters       => $chapters,
             patron_notes   => $notes,
+            format         => $format,
         }
     )->store();
 


### PR DESCRIPTION
We set default values for format if it does not come from API request, otherwise Koha almost silently dies with Koha::Exceptions::ArticleRequest::WrongFormat (for a moment of a patch formats was SCAN|PHOTOCOPY, check the pref value below)